### PR TITLE
# 키워드 및 검색 관련 Rest API 구현

### DIFF
--- a/BackEnd/src/app.ts
+++ b/BackEnd/src/app.ts
@@ -8,6 +8,7 @@ import { createConnection } from 'typeorm';
 import docsRouter from '@/routes/docs';
 import authRouter from '@/routes/auth';
 import questionRouter from '@/routes/question';
+import searchRouter from '@/routes/search';
 
 import { DEV_CONFIG, PROD_CONFIG } from '@/constants/index';
 import typeOrmConfig from '@/database/config/ormconfig';
@@ -51,6 +52,7 @@ app.use(
 app.use('/api-docs', docsRouter);
 app.use('/auth', authRouter);
 app.use('/question', questionRouter);
+app.use('/search', searchRouter);
 
 app.get('/', (_, res) => {
   res.status(200).send('KUAGORA Server has been Enabled.');

--- a/BackEnd/src/database/controllers/question.ts
+++ b/BackEnd/src/database/controllers/question.ts
@@ -164,55 +164,6 @@ export const getQuestionList = async (
   return questionDatas;
 };
 
-export const searchQuestionByWord = async (
-  word: string,
-  page: number,
-  amount: number,
-) => {
-  let questionDatas = undefined;
-  questionDatas = await getRepository(Question)
-    .createQueryBuilder('question')
-    .select([
-      'question.id',
-      'question.title',
-      'question.content',
-      'question.state',
-      'question.createdAt',
-      'user.uuid',
-      'user.nickname',
-      'keyword.id',
-      'keyword.content',
-    ])
-    .innerJoin(
-      (qb) =>
-        qb
-          .select([
-            'subQuestion.id',
-            'COUNT(likes.id) AS likeCount',
-            'COUNT(comments.id) AS CommentCount',
-          ])
-          .from(Question, 'subQuestion')
-          .where('subQuestion.title like :word', { word: `%${word}%` }) // like 절 사용법은 좌측과 같음.
-          .leftJoin('subQuestion.comments', 'comments')
-          .leftJoin('subQuestion.likes', 'likes')
-          .groupBy('subQuestion.id')
-          .offset((page - 1) * amount)
-          .limit(amount),
-      'topQuestion',
-      'topQuestion.subQuestion_id = question.id',
-    )
-    .leftJoin('question.user', 'user')
-    .leftJoin('question.keywords', 'keyword')
-    .loadRelationCountAndMap('question.likeCount', 'question.likes')
-    .loadRelationCountAndMap('question.commentCount', 'question.comments')
-    .orderBy('question.createdAt', 'DESC')
-    .offset((page - 1) * amount)
-    .limit(amount)
-    .getMany();
-
-  return questionDatas;
-};
-
 /**
  * 새로운 질문글을 등록하는 함수
  * @param title 질문글 제목

--- a/BackEnd/src/database/controllers/search.ts
+++ b/BackEnd/src/database/controllers/search.ts
@@ -1,18 +1,20 @@
 import { getRepository } from 'typeorm';
 import Question from '@/database/entity/question';
 
-export const searchQuestionByTitle = async (
-  title: string,
+/**
+ * 특정 검색어와 제목이 매칭하는 질문글 목록을 가져오는 함수
+ * @param word 검색을 진행할 문자열
+ * @param page 질문글을 보여줄 페이지
+ * @param amount 하나의 페이지에 보여줄 질문글의 수량
+ * @returns 검색을 통해 나온 질문글 정보 목록
+ */
+export const getQuestionByWord = async (
+  word: string,
   page: number,
   amount: number,
-  option: 'recent' | 'popular',
 ) => {
-  const sortType = {
-    recent: 'question.createdAt',
-    popular: 'likeAmount',
-  };
-
-  const questionsByTitle = await getRepository(Question)
+  let questionDatas = undefined;
+  questionDatas = await getRepository(Question)
     .createQueryBuilder('question')
     .select([
       'question.id',
@@ -20,26 +22,79 @@ export const searchQuestionByTitle = async (
       'question.content',
       'question.state',
       'question.createdAt',
-      'question.updatedAt',
+      'user.uuid',
+      'user.nickname',
+      'keyword.id',
+      'keyword.content',
     ])
     .innerJoin(
       (qb) =>
         qb
-          .select(['subquestion.id', 'COUNT(likes.id) AS likeCount'])
-          .from(Question, 'subquestion')
-          .where('subquestion.title like :title', { title: `%${title}` })
-          .leftJoin('subquestion.likes', 'likes')
-          .groupBy('subquestion.id')
+          .select([
+            'subQuestion.id',
+            'COUNT(likes.id) AS likeCount',
+            'COUNT(comments.id) AS CommentCount',
+          ])
+          .from(Question, 'subQuestion')
+          .where('subQuestion.title like :word', { word: `%${word}%` }) // like 절 사용법은 좌측과 같음.
+          .leftJoin('subQuestion.comments', 'comments')
+          .leftJoin('subQuestion.likes', 'likes')
+          .groupBy('subQuestion.id')
           .offset((page - 1) * amount)
-          .limit(amount)
-          .orderBy(sortType[option], 'DESC'),
+          .limit(amount),
       'topQuestion',
-      'topQuestion.id == question.id',
+      'topQuestion.subQuestion_id = question.id',
     )
-    .leftJoinAndSelect('question.user', 'user')
-    .leftJoinAndSelect('question.category', 'category')
-    .loadRelationCountAndMap('question.likes', 'likeCount')
+    .leftJoin('question.user', 'user')
+    .leftJoin('question.keywords', 'keyword')
+    .loadRelationCountAndMap('question.likeCount', 'question.likes')
+    .loadRelationCountAndMap('question.commentCount', 'question.comments')
+    .orderBy('question.createdAt', 'DESC')
+    .offset((page - 1) * amount)
+    .limit(amount)
     .getMany();
 
-  return questionsByTitle;
+  return questionDatas;
+};
+
+export const getQuestionByKeyword = async (
+  keyword: string,
+  page: number,
+  amount: number,
+) => {
+  const searchQuestionResult = await getRepository(Question)
+    .createQueryBuilder('question')
+    .select([
+      'question.id',
+      'question.title',
+      'question.content',
+      'question.state',
+      'question.createdAt',
+      'user.uuid',
+      'user.nickname',
+    ])
+    .innerJoin(
+      (qb) =>
+        qb
+          .select(['subQuestion.id', 'COUNT(comments.id) AS commentCount'])
+          .from(Question, 'subQuestion')
+          .where('keywords.content = :keyword', { keyword })
+          .leftJoin('subQuestion.comments', 'comments')
+          .leftJoin('subQuestion.keywords', 'keywords')
+          .groupBy('subQuestion.id')
+          .offset((page - 1) * amount)
+          .limit(amount)
+          .orderBy('subQuestion.createdAt', 'DESC'),
+      'topQuestion',
+      'topQuestion.subQuestion_id = question.id',
+    )
+    .leftJoin('question.user', 'user')
+    .leftJoinAndSelect('question.keywords', 'keywords')
+    .loadRelationCountAndMap('question.commentCount', 'question.comments')
+    .orderBy('question.createdAt', 'DESC')
+    .offset((page - 1) * amount)
+    .limit(amount)
+    .getMany();
+
+  return searchQuestionResult;
 };

--- a/BackEnd/src/database/controllers/search.ts
+++ b/BackEnd/src/database/controllers/search.ts
@@ -21,7 +21,7 @@ export const getQuestionByWord = async (
     },
     popular: {
       subQuery: 'likeCount',
-      query: 'question.likeCount',
+      query: 'topQuestion.likeCount',
     },
   };
 
@@ -83,7 +83,7 @@ export const getQuestionByKeyword = async (
     },
     popular: {
       subQuery: 'likeCount',
-      query: 'question.likeCount',
+      query: 'topQuestion.likeCount',
     },
   };
 
@@ -97,6 +97,8 @@ export const getQuestionByKeyword = async (
       'question.createdAt',
       'user.uuid',
       'user.nickname',
+      'keyword.id',
+      'keyword.content',
     ])
     .innerJoin(
       (qb) =>
@@ -120,6 +122,7 @@ export const getQuestionByKeyword = async (
     )
     .leftJoin('question.user', 'user')
     .leftJoinAndSelect('question.keywords', 'keywords')
+    .loadRelationCountAndMap('question.likeCount', 'question.likes')
     .loadRelationCountAndMap('question.commentCount', 'question.comments')
     .orderBy(sortType[option].query, 'DESC')
     .offset((page - 1) * amount)

--- a/BackEnd/src/routes/question.ts
+++ b/BackEnd/src/routes/question.ts
@@ -24,13 +24,13 @@ const questionRouter = express.Router();
 questionRouter.get(
   '/',
   wrapAsync(async (req: Request, res: Response, next: NextFunction) => {
-    const { page = '1', amount = '12', option = 'recent' } = req.query;
+    const { page = '1', amount = '12', sortOption = 'recent' } = req.query;
     const [pageNum, amountNum] = [Number(page), Number(amount)];
     if (
       pageNum * amountNum > 0 &&
-      (option == 'recent' || option == 'popular')
+      (sortOption == 'recent' || sortOption == 'popular')
     ) {
-      const questions = await getQuestionList(pageNum, amountNum, option);
+      const questions = await getQuestionList(pageNum, amountNum, sortOption);
       return res.status(200).json(questions);
     }
 

--- a/BackEnd/src/routes/question.ts
+++ b/BackEnd/src/routes/question.ts
@@ -14,7 +14,6 @@ import {
   getKeyword,
   removeKeyword,
   patchQuestionState,
-  searchQuestionByWord,
 } from '@/database/controllers/question';
 import { BadRequestError, UnauthorizedError } from '@/errors/definedErrors';
 import { checkLoggedIn } from '@/routes/jwt';
@@ -38,27 +37,6 @@ questionRouter.get(
     throw new BadRequestError(
       '잘못된 쿼리 요청입니다. 양식에 맞춰 재전송 해주세요.',
     );
-  }),
-);
-
-questionRouter.get(
-  '/search',
-  wrapAsync(async (req: Request, res: Response, next: NextFunction) => {
-    const { page = '1', amount = '12', word = '' } = req.query;
-    const [pageNum, amountNum] = [Number(page), Number(amount)];
-
-    if (!pageNum || !amountNum || !word) {
-      throw new BadRequestError(
-        '잘못된 쿼리 요청입니다. 양식에 맞춰 재전송 해주세요.',
-      );
-    }
-
-    const questions = await searchQuestionByWord(
-      word as string,
-      pageNum,
-      amountNum,
-    );
-    return res.status(200).json(questions);
   }),
 );
 

--- a/BackEnd/src/routes/search.ts
+++ b/BackEnd/src/routes/search.ts
@@ -1,0 +1,54 @@
+import express, { Request, Response, NextFunction } from 'express';
+
+import {
+  getQuestionByWord,
+  getQuestionByKeyword,
+} from '@/database/controllers/search';
+import { BadRequestError } from '@/errors/definedErrors';
+import { wrapAsync } from '@/utils/wrapAsync';
+
+const searchRouter = express.Router();
+
+searchRouter.get(
+  '/title',
+  wrapAsync(async (req: Request, res: Response, next: NextFunction) => {
+    const { page = '1', amount = '12', word = '' } = req.query;
+    const [pageNum, amountNum] = [Number(page), Number(amount)];
+
+    if (!pageNum || !amountNum || !word) {
+      throw new BadRequestError(
+        '잘못된 쿼리 요청입니다. 양식에 맞춰 재전송 해주세요.',
+      );
+    }
+
+    const questions = await getQuestionByWord(
+      word as string,
+      pageNum,
+      amountNum,
+    );
+    return res.status(200).json(questions);
+  }),
+);
+
+searchRouter.get(
+  '/keyword',
+  wrapAsync(async (req: Request, res: Response, next: NextFunction) => {
+    const { page = '1', amount = '12', keyword = '' } = req.query;
+    const [pageNum, amountNum] = [Number(page), Number(amount)];
+
+    if (!pageNum || !amountNum || !keyword) {
+      throw new BadRequestError(
+        '잘못된 쿼리 요청입니다. 양식에 맞춰 재전송 해주세요.',
+      );
+    }
+
+    const questions = await getQuestionByKeyword(
+      keyword as string,
+      pageNum,
+      amountNum,
+    );
+    return res.status(200).json(questions);
+  }),
+);
+
+export default searchRouter;

--- a/BackEnd/src/routes/search.ts
+++ b/BackEnd/src/routes/search.ts
@@ -12,42 +12,61 @@ const searchRouter = express.Router();
 searchRouter.get(
   '/title',
   wrapAsync(async (req: Request, res: Response, next: NextFunction) => {
-    const { page = '1', amount = '12', word = '' } = req.query;
+    const {
+      page = '1',
+      amount = '12',
+      query = '',
+      sortOption = 'recent',
+    } = req.query;
     const [pageNum, amountNum] = [Number(page), Number(amount)];
 
-    if (!pageNum || !amountNum || !word) {
-      throw new BadRequestError(
-        '잘못된 쿼리 요청입니다. 양식에 맞춰 재전송 해주세요.',
+    if (
+      pageNum > 0 &&
+      amountNum > 0 &&
+      (sortOption === 'recent' || sortOption === 'popular')
+    ) {
+      const questions = await getQuestionByWord(
+        query as string,
+        pageNum,
+        amountNum,
+        sortOption,
       );
+      return res.status(200).json(questions);
     }
 
-    const questions = await getQuestionByWord(
-      word as string,
-      pageNum,
-      amountNum,
+    throw new BadRequestError(
+      '잘못된 쿼리 요청입니다. 양식에 맞춰 재전송 해주세요.',
     );
-    return res.status(200).json(questions);
   }),
 );
 
 searchRouter.get(
   '/keyword',
   wrapAsync(async (req: Request, res: Response, next: NextFunction) => {
-    const { page = '1', amount = '12', keyword = '' } = req.query;
+    const {
+      page = '1',
+      amount = '12',
+      query = '',
+      sortOption = 'recent',
+    } = req.query;
     const [pageNum, amountNum] = [Number(page), Number(amount)];
-
-    if (!pageNum || !amountNum || !keyword) {
-      throw new BadRequestError(
-        '잘못된 쿼리 요청입니다. 양식에 맞춰 재전송 해주세요.',
+    if (
+      pageNum > 0 &&
+      amountNum > 0 &&
+      (sortOption === 'recent' || sortOption === 'popular')
+    ) {
+      const questions = await getQuestionByKeyword(
+        query as string,
+        pageNum,
+        amountNum,
+        sortOption,
       );
+      return res.status(200).json(questions);
     }
 
-    const questions = await getQuestionByKeyword(
-      keyword as string,
-      pageNum,
-      amountNum,
+    throw new BadRequestError(
+      '잘못된 쿼리 요청입니다. 양식에 맞춰 재전송 해주세요.',
     );
-    return res.status(200).json(questions);
   }),
 );
 


### PR DESCRIPTION
## Epic
키워드 및 검색 기능 구현 (#24)
질문글 목록 요청에 대한 Rest API 설계 (#11)

## Desc
- 글의 제목, 카테고리 검색을 통해 조건에 맞는 질문글 목록을 불러오는 Controller를 추가하였습니다.
- 하나의 route에 검색과 질문글 관련 로직이 묶여있던 것을 세분화하여, 검색 관련 route를 별도로 신설하였습니다.
- 질문글 정렬 기준을 추가 (시간 순, 추천 순, 댓글 순) 하여 조건에 맞는 검색 결과를 쿼리문에서 정렬시켜 제공하였습니다.
- 변경된 API 명세에 맞게 관련 로직을 일부 수정하였습니다.
