### PR TITLE
# 메인 페이지 레이아웃 구조 변경 

### DIFF
--- a/FrontEnd/src/components/main/Home/HeadLine/HeadLine.style.tsx
+++ b/FrontEnd/src/components/main/Home/HeadLine/HeadLine.style.tsx
@@ -16,10 +16,9 @@ export const Wrapper = styled.div<StyledHeadlineWrapperProps>`
       gap: 48px;
 
       width: 100%;
-      height: 700px;
+      height: 600px;
 
-      background: linear-gradient(rgba(0, 0, 0, 0.6), rgba(0, 0, 0, 0.25)),
-        url(${image.src});
+      background: linear-gradient(rgba(0, 0, 0, 0.6), rgba(0, 0, 0, 0.25)), url(${image.src});
       background-size: cover;
     `;
   }}

--- a/FrontEnd/src/components/main/Home/HeadLine/HeadLine.tsx
+++ b/FrontEnd/src/components/main/Home/HeadLine/HeadLine.tsx
@@ -12,22 +12,16 @@ const Headline = ({ isLogin }: HeadlineProps) => {
   const router = useRouter();
 
   const clickSubmitBtn = () => {
-    if (!isLogin) {
-      router.push("/login");
-    }
+    router.push(isLogin ? "/write" : "/login");
   };
 
   return (
     <style.Wrapper image={HeadLineImg}>
       <style.TextBox>
         <style.MainText>지식의 요람, KU : AGORA</style.MainText>
-        <style.SubText>
-          겹겹이 쌓인 질문 속에서 해답을 찾아보세요.
-        </style.SubText>
+        <style.SubText>겹겹이 쌓인 질문 속에서 해답을 찾아보세요.</style.SubText>
       </style.TextBox>
-      <style.SubmitButton onClick={clickSubmitBtn}>
-        지금 질문하기
-      </style.SubmitButton>
+      <style.SubmitButton onClick={clickSubmitBtn}>지금 질문하기</style.SubmitButton>
     </style.Wrapper>
   );
 };

--- a/FrontEnd/src/components/main/Question/QuestionList/QuestionList.tsx
+++ b/FrontEnd/src/components/main/Question/QuestionList/QuestionList.tsx
@@ -2,26 +2,26 @@ import * as style from "./QuestionList.style";
 
 import QuestionContext from "@/components/main/Question/QuestionList/QuestionContext";
 import { QuestionPostType } from "@/apis/question";
-import { QuestionContextProps } from "./QuestionContext";
 
 interface QuestionListProps {
-  questions: QuestionPostType[];
+  questions: QuestionPostType[] | undefined;
 }
 
 const QuestionList = ({ questions }: QuestionListProps) => {
   return (
     <style.Wrapper>
       <style.QuestionBox>
-        {questions.map(({ id, title, likeCount, commentCount, state }: QuestionPostType) => (
-          <QuestionContext
-            title={title}
-            like={likeCount}
-            comment={commentCount}
-            state={state}
-            questionId={id}
-            key={id}
-          />
-        ))}
+        {questions &&
+          questions.map(({ id, title, likeCount, commentCount, state }: QuestionPostType) => (
+            <QuestionContext
+              title={title}
+              like={likeCount}
+              comment={commentCount}
+              state={state}
+              questionId={id}
+              key={id}
+            />
+          ))}
       </style.QuestionBox>
     </style.Wrapper>
   );

--- a/FrontEnd/src/components/template/MainTemplate/MainTemplate.tsx
+++ b/FrontEnd/src/components/template/MainTemplate/MainTemplate.tsx
@@ -1,6 +1,6 @@
 import { useAtom } from "jotai";
 import { accessTokenAtom } from "@/stores/actions";
-import { QuestionPostType } from "@/apis/question";
+import { getQuestionsAsync, QuestionPostType } from "@/apis/question";
 
 import TitleBox from "@/components/common/TitleBox";
 import Navbar from "@/components/common/Navbar";
@@ -10,20 +10,23 @@ import Information from "@/components/main/Home/Information";
 import QuestionList from "@/components/main/Question/QuestionList";
 
 interface MainTemplateProps {
-  questions: QuestionPostType[];
+  recentQuestions: QuestionPostType[];
+  popularQuestions: QuestionPostType[];
 }
 
-const MainTemplate = ({ questions }: MainTemplateProps) => {
+const MainTemplate = ({ recentQuestions, popularQuestions }: MainTemplateProps) => {
   const [accessToken] = useAtom(accessTokenAtom);
 
   return (
     <>
       <Navbar />
       <HeadLine isLogin={accessToken != null} />
-      <TitleBox title={"Our Service"} subTitle={"지식의 요람. [KU : AGORA] 에 대해 소개합니다."} />
+      <TitleBox title={"Today Questions"} subTitle={"학우 분들이 최근에 등록한 질문글 목록입니다."} />
+      <QuestionList questions={recentQuestions} />
+      <TitleBox title={"Popular Questions"} subTitle={"학우 분들에게 인기 있는 질문글 목록입니다."} />
+      <QuestionList questions={popularQuestions} />
+      <TitleBox title={"Our Service"} subTitle={"KU : AGORA 의 서비스에 대한 설명입니다."} />
       <Information />
-      <TitleBox title={"Today Questions"} subTitle={"학우 분들이 가장 최근에 등록한 질문글 목록입니다."} />
-      <QuestionList questions={questions} />
       <Footer />
     </>
   );

--- a/FrontEnd/src/components/template/MainTemplate/MainTemplate.tsx
+++ b/FrontEnd/src/components/template/MainTemplate/MainTemplate.tsx
@@ -1,12 +1,11 @@
 import { useAtom } from "jotai";
 import { accessTokenAtom } from "@/stores/actions";
-import { getQuestionsAsync, QuestionPostType } from "@/apis/question";
+import { QuestionPostType } from "@/apis/question";
 
 import TitleBox from "@/components/common/TitleBox";
 import Navbar from "@/components/common/Navbar";
 import Footer from "@/components/common/Footer";
 import HeadLine from "@/components/main/Home/HeadLine";
-import Information from "@/components/main/Home/Information";
 import QuestionList from "@/components/main/Question/QuestionList";
 
 interface MainTemplateProps {
@@ -25,8 +24,6 @@ const MainTemplate = ({ recentQuestions, popularQuestions }: MainTemplateProps) 
       <QuestionList questions={recentQuestions} />
       <TitleBox title={"Popular Questions"} subTitle={"학우 분들에게 인기 있는 질문글 목록입니다."} />
       <QuestionList questions={popularQuestions} />
-      <TitleBox title={"Our Service"} subTitle={"KU : AGORA 의 서비스에 대한 설명입니다."} />
-      <Information />
       <Footer />
     </>
   );

--- a/FrontEnd/src/pages/index.tsx
+++ b/FrontEnd/src/pages/index.tsx
@@ -4,18 +4,25 @@ import MainTemplate from "@/components/template/MainTemplate";
 import { QuestionPostType, getQuestionsAsync } from "@/apis/question";
 
 interface QuestionsPageProps {
-  questions: QuestionPostType[];
+  recentQuestions: QuestionPostType[];
+  popularQuestions: QuestionPostType[];
 }
 
-export async function getStaticProps() {
-  const response = await getQuestionsAsync(1, 8, "recent");
+export async function getServerSideProps() {
+  const [recentQuestions, popularQuestions] = await Promise.all([
+    getQuestionsAsync(1, 8, "recent"),
+    getQuestionsAsync(1, 8, "popular")
+  ]);
+
   return {
-    props: { questions: response.isSuccess ? response.result.content : [] }
+    props: {
+      recentQuestions: recentQuestions.isSuccess ? recentQuestions.result.content : [],
+      popularQuestions: popularQuestions.isSuccess ? popularQuestions.result.content : []
+    }
   };
 }
 
-const Home = ({ questions }: QuestionsPageProps) => {
-  console.log(questions);
+const Home = ({ recentQuestions, popularQuestions }: QuestionsPageProps) => {
   return (
     <>
       <Head>
@@ -25,7 +32,7 @@ const Home = ({ questions }: QuestionsPageProps) => {
         <link rel="icon" href="/favicon.ico" />
         <title>지식의 요람, KU : AGORA</title>
       </Head>
-      <MainTemplate questions={questions} />
+      <MainTemplate recentQuestions={recentQuestions} popularQuestions={popularQuestions} />
     </>
   );
 };


### PR DESCRIPTION
## Topic
메인 페이지의 레이아웃 구성을 유저 친화적으로 재구성 (#32)

## Desc
- 유저들이 가장 최근에 업로드한 글 8개를 선별하여 보여주는 레이아웃 추가
- 유저들이 가장 좋아요를 많이 누른 글 8개를 선별하여 보여주는 레이아웃 추가
- 사이트 정보 컴포넌트를 메인 페이지에서 제거하였음.
- "지금 질문하기" 버튼 클릭 시, 질문글 작성 페이지로 이동하도록 수정. (비로그인 시 로그인 이동)