### PR TITLE
# 질문글 API에 채택 / 미채택 분류 옵션 추가

### DIFF
--- a/BackEnd/src/constants/question.ts
+++ b/BackEnd/src/constants/question.ts
@@ -1,0 +1,19 @@
+export const SORT_TYPE = {
+  recent: {
+    subQuery: 'subQuestion.createdAt',
+    query: 'question.createdAt',
+  },
+  popular: {
+    subQuery: 'likeCount',
+    query: 'topQuestion.likeCount',
+  },
+} as const;
+
+export const ANSWERED_TYPE = {
+  progressed: ['progressed'],
+  completed: ['completed'],
+  both: ['progressed', 'completed'],
+} as const;
+
+export type SortOptionType = keyof typeof SORT_TYPE;
+export type AnsweredOptionType = keyof typeof ANSWERED_TYPE;

--- a/BackEnd/src/database/controllers/search.ts
+++ b/BackEnd/src/database/controllers/search.ts
@@ -1,4 +1,11 @@
 import { getRepository } from 'typeorm';
+
+import {
+  SORT_TYPE,
+  ANSWERED_TYPE,
+  SortOptionType,
+  AnsweredOptionType,
+} from '@/constants/question';
 import Question from '@/database/entity/question';
 
 /**
@@ -12,8 +19,8 @@ export const getQuestionByWord = async (
   word: string,
   page: number,
   amount: number,
-  sortOption: 'recent' | 'popular',
-  answeredOption: 'progressed' | 'completed' | 'both',
+  sortOption: SortOptionType,
+  answeredOption: AnsweredOptionType,
 ) => {
   const sortType = {
     recent: {
@@ -56,12 +63,12 @@ export const getQuestionByWord = async (
           .from(Question, 'subQuestion')
           .where('subQuestion.title like :word', { word: `%${word}%` }) // like 절 사용법은 좌측과 같음.
           .andWhere('subQuestion.state IN(:...answeredStates)', {
-            answeredStates: answeredType[answeredOption],
+            answeredStates: ANSWERED_TYPE[answeredOption],
           })
           .leftJoin('subQuestion.comments', 'comments')
           .leftJoin('subQuestion.likes', 'likes')
           .groupBy('subQuestion.id')
-          .orderBy(sortType[sortOption].subQuery, 'DESC')
+          .orderBy(SORT_TYPE[sortOption].subQuery, 'DESC')
           .offset((page - 1) * amount)
           .limit(amount),
       'topQuestion',
@@ -71,7 +78,7 @@ export const getQuestionByWord = async (
     .leftJoin('question.keywords', 'keyword')
     .loadRelationCountAndMap('question.likeCount', 'question.likes')
     .loadRelationCountAndMap('question.commentCount', 'question.comments')
-    .orderBy(sortType[sortOption].query, 'DESC')
+    .orderBy(SORT_TYPE[sortOption].query, 'DESC')
     .getMany();
 
   return questionDatas;
@@ -81,25 +88,9 @@ export const getQuestionByKeyword = async (
   keyword: string,
   page: number,
   amount: number,
-  sortOption: 'recent' | 'popular',
-  answeredOption: 'progressed' | 'completed' | 'both',
+  sortOption: SortOptionType,
+  answeredOption: AnsweredOptionType,
 ) => {
-  const sortType = {
-    recent: {
-      subQuery: 'subQuestion.createdAt',
-      query: 'question.createdAt',
-    },
-    popular: {
-      subQuery: 'likeCount',
-      query: 'topQuestion.likeCount',
-    },
-  };
-  const answeredType = {
-    progressed: ['progressed'],
-    completed: ['completed'],
-    both: ['progressed', 'completed'],
-  };
-
   const searchQuestionResult = await getRepository(Question)
     .createQueryBuilder('question')
     .select([
@@ -124,13 +115,13 @@ export const getQuestionByKeyword = async (
           .from(Question, 'subQuestion')
           .where('keywords.content = :keyword', { keyword })
           .andWhere('subQuestion.state IN(:...answeredStates)', {
-            answeredStates: answeredType[answeredOption],
+            answeredStates: ANSWERED_TYPE[answeredOption],
           })
           .leftJoin('subQuestion.comments', 'comments')
           .leftJoin('subQuestion.likes', 'likes')
           .leftJoin('subQuestion.keywords', 'keywords')
           .groupBy('subQuestion.id')
-          .orderBy(sortType[sortOption].subQuery, 'DESC')
+          .orderBy(SORT_TYPE[sortOption].subQuery, 'DESC')
           .offset((page - 1) * amount)
           .limit(amount),
       'topQuestion',
@@ -140,7 +131,7 @@ export const getQuestionByKeyword = async (
     .leftJoinAndSelect('question.keywords', 'keywords')
     .loadRelationCountAndMap('question.likeCount', 'question.likes')
     .loadRelationCountAndMap('question.commentCount', 'question.comments')
-    .orderBy(sortType[sortOption].query, 'DESC')
+    .orderBy(SORT_TYPE[sortOption].query, 'DESC')
     .getMany();
 
   return searchQuestionResult;

--- a/BackEnd/src/database/controllers/search.ts
+++ b/BackEnd/src/database/controllers/search.ts
@@ -12,7 +12,8 @@ export const getQuestionByWord = async (
   word: string,
   page: number,
   amount: number,
-  option: 'recent' | 'popular',
+  sortOption: 'recent' | 'popular',
+  answeredOption: 'progressed' | 'completed' | 'both',
 ) => {
   const sortType = {
     recent: {
@@ -23,6 +24,11 @@ export const getQuestionByWord = async (
       subQuery: 'likeCount',
       query: 'topQuestion.likeCount',
     },
+  };
+  const answeredType = {
+    progressed: ['progressed'],
+    completed: ['completed'],
+    both: ['progressed', 'completed'],
   };
 
   let questionDatas = undefined;
@@ -49,10 +55,13 @@ export const getQuestionByWord = async (
           ])
           .from(Question, 'subQuestion')
           .where('subQuestion.title like :word', { word: `%${word}%` }) // like 절 사용법은 좌측과 같음.
+          .andWhere('subQuestion.state IN(:...answeredStates)', {
+            answeredStates: answeredType[answeredOption],
+          })
           .leftJoin('subQuestion.comments', 'comments')
           .leftJoin('subQuestion.likes', 'likes')
           .groupBy('subQuestion.id')
-          .orderBy(sortType[option].subQuery, 'DESC')
+          .orderBy(sortType[sortOption].subQuery, 'DESC')
           .offset((page - 1) * amount)
           .limit(amount),
       'topQuestion',
@@ -62,7 +71,7 @@ export const getQuestionByWord = async (
     .leftJoin('question.keywords', 'keyword')
     .loadRelationCountAndMap('question.likeCount', 'question.likes')
     .loadRelationCountAndMap('question.commentCount', 'question.comments')
-    .orderBy(sortType[option].query, 'DESC')
+    .orderBy(sortType[sortOption].query, 'DESC')
     .getMany();
 
   return questionDatas;
@@ -72,7 +81,8 @@ export const getQuestionByKeyword = async (
   keyword: string,
   page: number,
   amount: number,
-  option: 'recent' | 'popular',
+  sortOption: 'recent' | 'popular',
+  answeredOption: 'progressed' | 'completed' | 'both',
 ) => {
   const sortType = {
     recent: {
@@ -83,6 +93,11 @@ export const getQuestionByKeyword = async (
       subQuery: 'likeCount',
       query: 'topQuestion.likeCount',
     },
+  };
+  const answeredType = {
+    progressed: ['progressed'],
+    completed: ['completed'],
+    both: ['progressed', 'completed'],
   };
 
   const searchQuestionResult = await getRepository(Question)
@@ -108,11 +123,14 @@ export const getQuestionByKeyword = async (
           ])
           .from(Question, 'subQuestion')
           .where('keywords.content = :keyword', { keyword })
+          .andWhere('subQuestion.state IN(:...answeredStates)', {
+            answeredStates: answeredType[answeredOption],
+          })
           .leftJoin('subQuestion.comments', 'comments')
           .leftJoin('subQuestion.likes', 'likes')
           .leftJoin('subQuestion.keywords', 'keywords')
           .groupBy('subQuestion.id')
-          .orderBy(sortType[option].subQuery, 'DESC')
+          .orderBy(sortType[sortOption].subQuery, 'DESC')
           .offset((page - 1) * amount)
           .limit(amount),
       'topQuestion',
@@ -122,7 +140,7 @@ export const getQuestionByKeyword = async (
     .leftJoinAndSelect('question.keywords', 'keywords')
     .loadRelationCountAndMap('question.likeCount', 'question.likes')
     .loadRelationCountAndMap('question.commentCount', 'question.comments')
-    .orderBy(sortType[option].query, 'DESC')
+    .orderBy(sortType[sortOption].query, 'DESC')
     .getMany();
 
   return searchQuestionResult;

--- a/BackEnd/src/routes/question.ts
+++ b/BackEnd/src/routes/question.ts
@@ -1,6 +1,10 @@
 import express, { Request, Response, NextFunction } from 'express';
 
 import {
+  SortOptionType,
+  AnsweredOptionType,
+} from '@/constants/question';
+import {
   addQuestion,
   getQuestionList,
   getQuestionById,

--- a/BackEnd/src/routes/question.ts
+++ b/BackEnd/src/routes/question.ts
@@ -24,13 +24,21 @@ const questionRouter = express.Router();
 questionRouter.get(
   '/',
   wrapAsync(async (req: Request, res: Response, next: NextFunction) => {
-    const { page = '1', amount = '12', sortOption = 'recent' } = req.query;
+    const {
+      page = '1',
+      amount = '12',
+      sortOption = 'recent',
+      answeredOption = 'both',
+    } = req.query;
     const [pageNum, amountNum] = [Number(page), Number(amount)];
     if (
       pageNum * amountNum > 0 &&
-      (sortOption == 'recent' || sortOption == 'popular')
+      (sortOption == 'recent' || sortOption == 'popular') &&
+      (answeredOption == 'progressed' ||
+        answeredOption == 'completed' ||
+        answeredOption == 'both')
     ) {
-      const questions = await getQuestionList(pageNum, amountNum, sortOption);
+      const questions = await getQuestionList(pageNum, amountNum, sortOption, answeredOption);
       return res.status(200).json(questions);
     }
 

--- a/BackEnd/src/routes/search.ts
+++ b/BackEnd/src/routes/search.ts
@@ -17,19 +17,24 @@ searchRouter.get(
       amount = '12',
       query = '',
       sortOption = 'recent',
+      answeredOption = 'both',
     } = req.query;
     const [pageNum, amountNum] = [Number(page), Number(amount)];
 
     if (
       pageNum > 0 &&
       amountNum > 0 &&
-      (sortOption === 'recent' || sortOption === 'popular')
+      (sortOption === 'recent' || sortOption === 'popular') &&
+      (answeredOption == 'progressed' ||
+        answeredOption == 'completed' ||
+        answeredOption == 'both')
     ) {
       const questions = await getQuestionByWord(
         query as string,
         pageNum,
         amountNum,
         sortOption,
+        answeredOption,
       );
       return res.status(200).json(questions);
     }
@@ -48,18 +53,23 @@ searchRouter.get(
       amount = '12',
       query = '',
       sortOption = 'recent',
+      answeredOption = 'both',
     } = req.query;
     const [pageNum, amountNum] = [Number(page), Number(amount)];
     if (
       pageNum > 0 &&
       amountNum > 0 &&
-      (sortOption === 'recent' || sortOption === 'popular')
+      (sortOption === 'recent' || sortOption === 'popular') &&
+      (answeredOption == 'progressed' ||
+        answeredOption == 'completed' ||
+        answeredOption == 'both')
     ) {
       const questions = await getQuestionByKeyword(
         query as string,
         pageNum,
         amountNum,
         sortOption,
+        answeredOption,
       );
       return res.status(200).json(questions);
     }

--- a/BackEnd/src/types/question.ts
+++ b/BackEnd/src/types/question.ts
@@ -1,2 +1,0 @@
-export type SortType = 'recent' | 'option';
-export type StateType = 'progressed' | 'answered';


### PR DESCRIPTION
## Topic
채택 / 미채택 글 분류 옵션 추가 및 적용 (#34)

## Desc
- 채택 / 미채택 정렬 옵션을 추가하고, 클라이언트의 요청에 맞는 결과를 API에서 제공
- 채택 여부 옵션, 최신 / 인기 정렬 옵션 객체를 상수화하여 사용하도록 로직 수정