### PR TITLE
# 질문글 검색 바 컴포넌트 리팩터링

### DIFF
--- a/FrontEnd/src/components/main/Question/QuestionSearch/QuestionSearch.style.tsx
+++ b/FrontEnd/src/components/main/Question/QuestionSearch/QuestionSearch.style.tsx
@@ -1,7 +1,7 @@
 import styled, { css } from "styled-components";
 
 export const Wrapper = styled.div`
-  width: 1112px;
+  width: 964px;
   height: 48px;
   margin: 48px auto;
 

--- a/FrontEnd/src/components/main/Question/QuestionSearch/QuestionSearch.tsx
+++ b/FrontEnd/src/components/main/Question/QuestionSearch/QuestionSearch.tsx
@@ -1,4 +1,5 @@
 import { useRouter } from "next/router";
+import { useState } from "react";
 import { SelectType } from "@/constants/search";
 
 import * as style from "./QuestionSearch.style";
@@ -7,17 +8,19 @@ import SearchSvg from "@/assets/icons/Search.svg";
 import SearchOptionSelect from "@/components/main/Question/QuestionSearch/SearchOptionSelect";
 
 interface QuestionSearchProps {
-  searchQuery: string;
-  changeSearchQuery: (word: string) => void;
+  searchedQuery: string;
 }
 
-const QuestionSearch = ({ searchQuery, changeSearchQuery }: QuestionSearchProps) => {
+const QuestionSearch = ({ searchedQuery }: QuestionSearchProps) => {
   const router = useRouter();
+  const [searchQuery, setSearchQuery] = useState(searchedQuery);
 
+  // 검색 Input 내의 Value를 새롭게 업데이트 하는 함수
   const changeSearchInput = (e: React.ChangeEvent<HTMLInputElement>) => {
-    changeSearchQuery(e.target.value);
+    setSearchQuery(e.target.value);
   };
 
+  // Input에 입력된 query를 통해 검색된 결과 페이지로 이동하는 함수
   const searchQuestions = (e: React.KeyboardEvent<HTMLInputElement>) => {
     if (e.key == "Enter" && searchQuery.length > 1) {
       router.push({
@@ -27,6 +30,7 @@ const QuestionSearch = ({ searchQuery, changeSearchQuery }: QuestionSearchProps)
     }
   };
 
+  // 특정 정렬 옵션이 변경되었을 경우, 이를 filter state에 업데이트 하는 함수
   const changeSearchFilter = (option: SelectType, value: string) => {
     router.push({
       query: { ...router.query, [option]: value }

--- a/FrontEnd/src/components/main/Question/QuestionSearch/QuestionSearch.tsx
+++ b/FrontEnd/src/components/main/Question/QuestionSearch/QuestionSearch.tsx
@@ -17,15 +17,19 @@ const QuestionSearch = ({ searchedQuery }: QuestionSearchProps) => {
 
   // 검색 Input 내의 Value를 새롭게 업데이트 하는 함수
   const changeSearchInput = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setSearchQuery(e.target.value);
+    setSearchQuery(e.target.value.trim());
   };
 
   // Input에 입력된 query를 통해 검색된 결과 페이지로 이동하는 함수
   const searchQuestions = (e: React.KeyboardEvent<HTMLInputElement>) => {
     if (e.key == "Enter" && searchQuery.length > 1) {
+      // query 맨 앞에 # 가 있다면, 키워드 검색을 의미하므로 이를 적용해야 함.
+      const searchOption = searchQuery.charAt(0) === "#" ? "keyword" : "title";
+
+      // 검색 결과 페이지로 이동 (키워드의 경우 맨 앞의 # 를 제거하고 쿼리로 넘김)
       router.push({
         pathname: "/search",
-        query: { query: searchQuery }
+        query: { query: searchQuery.slice(searchOption === "keyword" ? 1 : 0), search: searchOption }
       });
     }
   };

--- a/FrontEnd/src/components/main/Question/QuestionSearch/QuestionSearch.tsx
+++ b/FrontEnd/src/components/main/Question/QuestionSearch/QuestionSearch.tsx
@@ -11,10 +11,7 @@ interface QuestionSearchProps {
   changeSearchQuery: (word: string) => void;
 }
 
-const QuestionSearch = ({
-  searchQuery,
-  changeSearchQuery
-}: QuestionSearchProps) => {
+const QuestionSearch = ({ searchQuery, changeSearchQuery }: QuestionSearchProps) => {
   const router = useRouter();
 
   const changeSearchInput = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -38,7 +35,6 @@ const QuestionSearch = ({
 
   return (
     <style.Wrapper>
-      <SearchOptionSelect selectType="search" changeSearchFilter={changeSearchFilter} />
       <SearchOptionSelect selectType="sort" changeSearchFilter={changeSearchFilter} />
       <SearchOptionSelect selectType="answered" changeSearchFilter={changeSearchFilter} />
       <style.SearchBar>

--- a/FrontEnd/src/components/template/QuestionsTemplate/QuestionsTemplate.tsx
+++ b/FrontEnd/src/components/template/QuestionsTemplate/QuestionsTemplate.tsx
@@ -10,16 +10,14 @@ import QuestionPost from "@/components/main/Question/QuestionPost";
 interface QuestionsTemplateProps {
   questions: QuestionPostType[] | undefined;
   questionRef: RefObject<HTMLDivElement>;
-  searchQuery: string;
-  changeSearchQuery: (newQuery: string) => void;
 }
 
-const QuestionsTemplate = ({ questions, questionRef, searchQuery, changeSearchQuery }: QuestionsTemplateProps) => {
+const QuestionsTemplate = ({ questions, questionRef }: QuestionsTemplateProps) => {
   return (
     <>
       <Navbar />
       <QuestionHeadline title={"Question List"} subtitle={"학우 분들이 남긴 다양한 질문을 확인해보세요."} />
-      <QuestionSearch searchQuery={searchQuery} changeSearchQuery={changeSearchQuery} />
+      <QuestionSearch searchedQuery={""} />
       <QuestionPost questions={questions} questionRef={questionRef} />
       <Footer />
     </>

--- a/FrontEnd/src/components/template/SearchTemplate/SearchTemplate.tsx
+++ b/FrontEnd/src/components/template/SearchTemplate/SearchTemplate.tsx
@@ -22,7 +22,7 @@ const SearchTemplate = ({ questions, questionRef, searchOption, searchedQuery }:
         title={"Search Result"}
         subtitle={`[${searchedQuery}] 에 대한 ${searchOption === "keyword" ? "키워드" : "제목"} 검색 결과입니다.`}
       />
-      <QuestionSearch searchedQuery={searchedQuery} />
+      <QuestionSearch searchedQuery={searchOption === "title" ? searchedQuery : `#${searchedQuery}`} />
       <QuestionPost questions={questions} questionRef={questionRef} />
       <Footer />
     </>

--- a/FrontEnd/src/components/template/SearchTemplate/SearchTemplate.tsx
+++ b/FrontEnd/src/components/template/SearchTemplate/SearchTemplate.tsx
@@ -1,5 +1,5 @@
 import { RefObject } from "react";
-import { QuestionPostType } from "@/apis/question";
+import { QuestionPostType, QuestionSearchType } from "@/apis/question";
 
 import Navbar from "@/components/common/Navbar";
 import Footer from "@/components/common/Footer";
@@ -10,14 +10,18 @@ import QuestionPost from "@/components/main/Question/QuestionPost";
 interface SearchTemplateProps {
   questions: QuestionPostType[] | undefined;
   questionRef: RefObject<HTMLDivElement>;
+  searchOption: QuestionSearchType;
   searchedQuery: string;
 }
 
-const SearchTemplate = ({ questions, questionRef, searchedQuery }: SearchTemplateProps) => {
+const SearchTemplate = ({ questions, questionRef, searchOption, searchedQuery }: SearchTemplateProps) => {
   return (
     <>
       <Navbar />
-      <QuestionHeadline title={"Search Result"} subtitle={`${searchedQuery} 에 대한 검색 결과입니다.`} />
+      <QuestionHeadline
+        title={"Search Result"}
+        subtitle={`[${searchedQuery}] 에 대한 ${searchOption === "keyword" ? "키워드" : "제목"} 검색 결과입니다.`}
+      />
       <QuestionSearch searchedQuery={searchedQuery} />
       <QuestionPost questions={questions} questionRef={questionRef} />
       <Footer />

--- a/FrontEnd/src/components/template/SearchTemplate/SearchTemplate.tsx
+++ b/FrontEnd/src/components/template/SearchTemplate/SearchTemplate.tsx
@@ -1,5 +1,5 @@
 import { RefObject } from "react";
-import { QuestionPostType, QuestionSearchType, QuestionSortType } from "@/apis/question";
+import { QuestionPostType } from "@/apis/question";
 
 import Navbar from "@/components/common/Navbar";
 import Footer from "@/components/common/Footer";
@@ -10,24 +10,15 @@ import QuestionPost from "@/components/main/Question/QuestionPost";
 interface SearchTemplateProps {
   questions: QuestionPostType[] | undefined;
   questionRef: RefObject<HTMLDivElement>;
-  searchQuery: string;
-  changeSearchQuery: (newQuery: string) => void;
+  searchedQuery: string;
 }
 
-const SearchTemplate = ({
-  questions,
-  questionRef,
-  searchQuery,
-  changeSearchQuery
-}: SearchTemplateProps) => {
+const SearchTemplate = ({ questions, questionRef, searchedQuery }: SearchTemplateProps) => {
   return (
     <>
       <Navbar />
-      <QuestionHeadline title={"Search Result"} subtitle={`${searchQuery} 에 대한 검색 결과입니다.`} />
-      <QuestionSearch
-        searchQuery={searchQuery}
-        changeSearchQuery={changeSearchQuery}
-      />
+      <QuestionHeadline title={"Search Result"} subtitle={`${searchedQuery} 에 대한 검색 결과입니다.`} />
+      <QuestionSearch searchedQuery={searchedQuery} />
       <QuestionPost questions={questions} questionRef={questionRef} />
       <Footer />
     </>

--- a/FrontEnd/src/constants/search.ts
+++ b/FrontEnd/src/constants/search.ts
@@ -31,7 +31,7 @@ const ANSWERED_OPTION: SelectInfoType[] = [
   },
   {
     option: "both",
-    display: "고려 안함"
+    display: "전체"
   }
 ];
 

--- a/FrontEnd/src/constants/search.ts
+++ b/FrontEnd/src/constants/search.ts
@@ -22,16 +22,16 @@ const SORT_OPTION: SelectInfoType[] = [
 
 const ANSWERED_OPTION: SelectInfoType[] = [
   {
+    option: "both",
+    display: "전체"
+  },
+  {
     option: "progressed",
     display: "미채택"
   },
   {
     option: "completed",
     display: "채택됨"
-  },
-  {
-    option: "both",
-    display: "전체"
   }
 ];
 

--- a/FrontEnd/src/pages/questions.tsx
+++ b/FrontEnd/src/pages/questions.tsx
@@ -1,20 +1,18 @@
 import Head from "next/head";
 
 import { useInfiniteQuery } from "react-query";
-import { useRef, useState } from "react";
+import { useRef } from "react";
 import { useRouter } from "next/router";
 
-import { getQuestionsAsync, QuestionSortType, QuestionSearchType, QuestionAnsweredType } from "@/apis/question";
+import { getQuestionsAsync, QuestionSortType, QuestionAnsweredType } from "@/apis/question";
 import QuestionsTemplate from "@/components/template/QuestionsTemplate";
 import useInfiniteScroll from "@/hooks/useInfiniteScroll";
 
 const Questions = () => {
   const router = useRouter();
   const questionRef = useRef(null);
-  const [searchQuery, setSearchQuery] = useState("");
 
-  const { search, sort, answered } = router.query;
-  const searchOption = (search || "title") as QuestionSearchType;
+  const { sort, answered } = router.query;
   const sortOption = (sort || "recent") as QuestionSortType;
   const answeredOption = (answered || "both") as QuestionAnsweredType;
   const amount = 12; // 1회 fetch 시 최대 12개의 질문글을 불러옴
@@ -49,11 +47,6 @@ const Questions = () => {
     }
   };
 
-  // 질문글 검색 바의 Value를 새롭게 변경해주는 함수.
-  const changeSearchQuery = (newQuery: string) => {
-    setSearchQuery(newQuery);
-  };
-
   useInfiniteScroll(questionRef, fetchNextQuestions);
 
   // useInfiniteQuery 로 받은 데이터를 페이지 별로 순회하여 API 성공 여부에 따른 값을 추가.
@@ -72,8 +65,6 @@ const Questions = () => {
       <QuestionsTemplate
         questions={questions}
         questionRef={questionRef}
-        searchQuery={searchQuery}
-        changeSearchQuery={changeSearchQuery}
       />
     </>
   );

--- a/FrontEnd/src/pages/search.tsx
+++ b/FrontEnd/src/pages/search.tsx
@@ -1,7 +1,7 @@
 import Head from "next/head";
 
 import { useInfiniteQuery } from "react-query";
-import { useRef, useState } from "react";
+import { useRef } from "react";
 import { useRouter } from "next/router";
 
 import { QuestionAnsweredType, QuestionSortType, QuestionSearchType, getQuestionsByQueryAsync } from "@/apis/question";
@@ -12,7 +12,6 @@ import SearchTemplate from "@/components/template/SearchTemplate";
 const Search = () => {
   const router = useRouter();
   const questionRef = useRef(null);
-  const [searchQuery, setSearchQuery] = useState("");
 
   const { query, search, sort, answered } = router.query;
   const searchedQuery = (query || "") as string;
@@ -52,11 +51,6 @@ const Search = () => {
     }
   };
 
-  // 질문글 검색 바의 Value를 새롭게 변경해주는 함수.
-  const changeSearchQuery = (newQuery: string) => {
-    setSearchQuery(newQuery);
-  };
-
   useInfiniteScroll(questionRef, fetchNextQuestions);
 
   // useInfiniteQuery 로 받은 데이터를 페이지 별로 순회하여 API 성공 여부에 따른 값을 추가.
@@ -72,12 +66,7 @@ const Search = () => {
         <link rel="icon" href="/favicon.ico" />
         <title>지식의 요람, KU : AGORA</title>
       </Head>
-      <SearchTemplate
-        questions={questions}
-        questionRef={questionRef}
-        searchQuery={searchQuery}
-        changeSearchQuery={changeSearchQuery}
-      />
+      <SearchTemplate questions={questions} questionRef={questionRef} searchedQuery={searchedQuery} />
     </>
   );
 };

--- a/FrontEnd/src/pages/search.tsx
+++ b/FrontEnd/src/pages/search.tsx
@@ -21,7 +21,7 @@ const Search = () => {
   const amount = 12; // 1회 fetch 시 최대 12개의 질문글을 불러옴
 
   const { data, hasNextPage, fetchNextPage } = useInfiniteQuery(
-    ["question", { sortOption, searchOption, answeredOption }],
+    ["question", { searchedQuery, sortOption, searchOption, answeredOption }],
     /**
      * useInfiniteQuery 쿼리에 할당된 콜백 함수
      * pageParam : 현재 useInfiniteQuery가 어떤 페이지에 있는지를 체크하는 파라미터 (기본 1 지정)
@@ -66,7 +66,12 @@ const Search = () => {
         <link rel="icon" href="/favicon.ico" />
         <title>지식의 요람, KU : AGORA</title>
       </Head>
-      <SearchTemplate questions={questions} questionRef={questionRef} searchedQuery={searchedQuery} />
+      <SearchTemplate
+        questions={questions}
+        questionRef={questionRef}
+        searchOption={searchOption}
+        searchedQuery={searchedQuery}
+      />
     </>
   );
 };


### PR DESCRIPTION
## Topic
질문글 검색 바를 독립적인 레이아웃으로 재설계 (#35)

## Desc

- 검색 바를 독립적인 Organism으로 분류하고, 관련 로직 또한 내부에 밀집시켜 정리.
- 페이지에 종속적이었던 검색 value State를 독립적으로 작동하도록 관련 로직을 리팩터링.
- 검색 옵션의 경우 키워드 별 / 제목 별 로만 두고, 그 외 옵션은 결과 페이지에서 필터링. 
- 검색 결과 페이지에서 키워드 / 제목 검색 조건을 헤더에서 보여주도록 레이아웃 수정.
- 채택 정렬 옵션의 기본 값 설명을 "고려 안함" 에서 "전체" 로 수정