### PR TITLE
# 좋아요 관련 Rest API 구현

### DIFF
--- a/BackEnd/src/database/controllers/question.ts
+++ b/BackEnd/src/database/controllers/question.ts
@@ -242,7 +242,7 @@ export const removeQuestion = async (questionId: number, uuid: string) => {
     .andWhere('question.id =: questionId', { questionId })
     .execute();
 
-  if (removeQuestiontResult.affected !== -1) {
+  if (removeQuestiontResult.affected === -1) {
     throw new BadRequestError(
       '존재하지 않는 질문글을 지우려 했거나, 자신이 지우지 않은 글을 지우려 했습니다.',
     );
@@ -334,7 +334,7 @@ export const removeComment = async (
     .andWhere('comment.user_uuid = :uuid', { uuid })
     .execute();
 
-  if (removeCommentResult.affected !== -1) {
+  if (removeCommentResult.affected === -1) {
     throw new BadRequestError(
       '존재하지 않는 댓글을 지우려 하셨거나, 자신이 작성하지 않은 댓글을 지우려 하셨습니다.',
     );
@@ -371,7 +371,7 @@ export const patchQuestionState = async (
     .where('comment.id = :commentId', { commentId })
     .execute();
 
-  if (editCommentStateResult.affected !== 1) {
+  if (editCommentStateResult.affected === 1) {
     throw new BadRequestError('존재하지 않는 댓글에 대한 요청입니다.');
   }
 };
@@ -415,7 +415,7 @@ export const addKeyword = async (questionId: number, content: string) => {
     .updateEntity(false)
     .execute();
 
-  if (addKeywordResult.raw.affected == -1) {
+  if (addKeywordResult.raw.affected === -1) {
     throw new BadRequestError(
       '존재하지 않는 게시글에 키워드를 추가하려 하였습니다.',
     );
@@ -439,7 +439,7 @@ export const removeKeyword = async (questionId: number, keywordId: number) => {
     .andWhere('keyword.id = :keywordId', { keywordId })
     .execute();
 
-  if (removeKeywordResult.affected !== -1) {
+  if (removeKeywordResult.affected === -1) {
     throw new BadRequestError(
       '존재하지 않는 게시글의 키워드를 삭제하려 했습니다.',
     );
@@ -471,7 +471,7 @@ export const addLike = async (questionId: number, uuid: string) => {
     .updateEntity(false)
     .execute();
 
-  if (addLikeResult.raw.affected == -1) {
+  if (addLikeResult.raw.affected === -1) {
     throw new BadRequestError(
       '존재하지 않는 게시글에 좋아요를 추가하려 하였습니다.',
     );
@@ -494,7 +494,9 @@ export const removeLike = async (questionId: number, uuid: string) => {
     .andWhere('like.user_uuid = :uuid', { uuid })
     .execute();
 
-  if (removeLikeResult.affected !== -1) {
+  console.log(removeLikeResult);
+
+  if (removeLikeResult.affected === -1) {
     throw new BadRequestError(
       '존재하지 않는 게시글의 좋아요를 수정하려 했거나, UUID가 유효하지 않습니다.',
     );

--- a/BackEnd/src/database/controllers/question.ts
+++ b/BackEnd/src/database/controllers/question.ts
@@ -435,8 +435,8 @@ export const removeKeyword = async (questionId: number, keywordId: number) => {
   const removeKeywordResult = await getRepository(Keyword)
     .createQueryBuilder('keyword')
     .softDelete()
-    .andWhere('keyword.question_id =: questionId', { questionId })
-    .andWhere('keyword.id =: keywordId', { keywordId })
+    .andWhere('keyword.question_id = :questionId', { questionId })
+    .andWhere('keyword.id = :keywordId', { keywordId })
     .execute();
 
   if (removeKeywordResult.affected !== -1) {
@@ -489,9 +489,9 @@ export const addLike = async (questionId: number, uuid: string) => {
 export const removeLike = async (questionId: number, uuid: string) => {
   const removeLikeResult = await getRepository(Like)
     .createQueryBuilder('like')
-    .softDelete()
-    .andWhere('like.question_id =: questionId', { questionId })
-    .andWhere('like.user_uuid =: uuid', { uuid })
+    .delete()
+    .where('like.question_id = :questionId', { questionId })
+    .andWhere('like.user_uuid = :uuid', { uuid })
     .execute();
 
   if (removeLikeResult.affected !== -1) {

--- a/BackEnd/src/database/controllers/question.ts
+++ b/BackEnd/src/database/controllers/question.ts
@@ -6,7 +6,12 @@ import Like from '@/database/entity/like';
 import Question from '@/database/entity/question';
 import User from '@/database/entity/user';
 
-import { SORT_TYPE, ANSWERED_TYPE, SortOptionType, AnsweredOptionType } from '@/constants/question';
+import {
+  SORT_TYPE,
+  ANSWERED_TYPE,
+  SortOptionType,
+  AnsweredOptionType,
+} from '@/constants/question';
 import { BadRequestError } from '@/errors/definedErrors';
 
 /**
@@ -91,6 +96,7 @@ export const getQuestionById = async (
     .where('question.id = :questionId', { questionId })
     .leftJoin('question.user', 'user')
     .leftJoinAndSelect('question.keywords', 'keyword')
+    .loadRelationCountAndMap('question.likeCount', 'question.likes')
     .getOne();
 
   // 게시글이 존재하는지를 먼저 확인. 타입 가드도 겸임.

--- a/BackEnd/src/database/controllers/question.ts
+++ b/BackEnd/src/database/controllers/question.ts
@@ -494,8 +494,6 @@ export const removeLike = async (questionId: number, uuid: string) => {
     .andWhere('like.user_uuid = :uuid', { uuid })
     .execute();
 
-  console.log(removeLikeResult);
-
   if (removeLikeResult.affected === -1) {
     throw new BadRequestError(
       '존재하지 않는 게시글의 좋아요를 수정하려 했거나, UUID가 유효하지 않습니다.',

--- a/BackEnd/src/database/controllers/search.ts
+++ b/BackEnd/src/database/controllers/search.ts
@@ -22,22 +22,6 @@ export const getQuestionByWord = async (
   sortOption: SortOptionType,
   answeredOption: AnsweredOptionType,
 ) => {
-  const sortType = {
-    recent: {
-      subQuery: 'subQuestion.createdAt',
-      query: 'question.createdAt',
-    },
-    popular: {
-      subQuery: 'likeCount',
-      query: 'topQuestion.likeCount',
-    },
-  };
-  const answeredType = {
-    progressed: ['progressed'],
-    completed: ['completed'],
-    both: ['progressed', 'completed'],
-  };
-
   let questionDatas = undefined;
   questionDatas = await getRepository(Question)
     .createQueryBuilder('question')
@@ -128,7 +112,7 @@ export const getQuestionByKeyword = async (
       'topQuestion.subQuestion_id = question.id',
     )
     .leftJoin('question.user', 'user')
-    .leftJoinAndSelect('question.keywords', 'keywords')
+    .leftJoinAndSelect('question.keywords', 'keyword')
     .loadRelationCountAndMap('question.likeCount', 'question.likes')
     .loadRelationCountAndMap('question.commentCount', 'question.comments')
     .orderBy(SORT_TYPE[sortOption].query, 'DESC')

--- a/BackEnd/src/database/entity/like.ts
+++ b/BackEnd/src/database/entity/like.ts
@@ -1,11 +1,13 @@
-import { Entity, ManyToOne, JoinColumn } from 'typeorm';
+import { Entity, ManyToOne, JoinColumn, PrimaryGeneratedColumn } from 'typeorm';
 
-import BasicEntity from './basic';
 import User from './user';
 import Question from './question';
 
 @Entity()
-class Like extends BasicEntity {
+class Like {
+  @PrimaryGeneratedColumn()
+  id!: number;
+
   // [Relation] Like : Question = N : 1
   @ManyToOne(() => Question, (question) => question.likes)
   @JoinColumn({

--- a/BackEnd/src/routes/auth.ts
+++ b/BackEnd/src/routes/auth.ts
@@ -47,13 +47,17 @@ authRouter.post(
     }
 
     if (userData) {
-      const { uuid } = userData;
+      const { uuid, nickname, email } = userData;
       const token = createJWT(uuid);
       const refreshToken = createRefreshJWT(uuid);
       await setRefreshToken(uuid, refreshToken);
       return res
         .status(200)
-        .json({ access_token: token, refresh_token: refreshToken, userData });
+        .json({
+          access_token: token,
+          refresh_token: refreshToken,
+          userData: { uuid, nickname, email },
+        });
     }
 
     // 정상적으로 로그인이 진행되지 않을 경우, 500 Internal Error 발생.

--- a/BackEnd/src/routes/question.ts
+++ b/BackEnd/src/routes/question.ts
@@ -1,9 +1,6 @@
 import express, { Request, Response, NextFunction } from 'express';
 
-import {
-  SortOptionType,
-  AnsweredOptionType,
-} from '@/constants/question';
+import { SortOptionType, AnsweredOptionType } from '@/constants/question';
 import {
   addQuestion,
   getQuestionList,
@@ -42,7 +39,12 @@ questionRouter.get(
         answeredOption == 'completed' ||
         answeredOption == 'both')
     ) {
-      const questions = await getQuestionList(pageNum, amountNum, sortOption, answeredOption);
+      const questions = await getQuestionList(
+        pageNum,
+        amountNum,
+        sortOption,
+        answeredOption,
+      );
       return res.status(200).json(questions);
     }
 

--- a/BackEnd/src/routes/question.ts
+++ b/BackEnd/src/routes/question.ts
@@ -236,6 +236,7 @@ questionRouter.delete(
     }
 
     await removeLike(questionId, uuid);
+    res.end();
   }),
 );
 


### PR DESCRIPTION
## Topic
질문글에 포함된 좋아요 및 댓글 추가, 조회, 삭제 구현 (#22)

## Desc

- 질문글 상세 API에서 좋아요 갯수가 누락되었던 버그 수정 
- 좋아요 엔티티의 생성, 수정 일자 칼럼를 제거하여 Soft Delete 지원 해제
- 쿼리문 정상 작동 여부를 파악하는 조건문의 오류를 일부 수정