### PR TITLE
# 리프레시 토큰 검증 로직 추가

### DIFF
--- a/BackEnd/src/auth/jwt.ts
+++ b/BackEnd/src/auth/jwt.ts
@@ -1,7 +1,7 @@
 import jwt from 'jsonwebtoken';
 import dotenv from 'dotenv';
 
-import { UnauthorizedError } from '@/errors/definedErrors';
+import { ExpireTokenError } from '@/errors/definedErrors';
 import User from '@/database/entity/user';
 
 dotenv.config();
@@ -14,7 +14,7 @@ dotenv.config();
  */
 export const createJWT = (uuid: string) => {
   const token = jwt.sign({ uuid }, process.env.JWT_SECRET_KEY!, {
-    expiresIn: '1h',
+    expiresIn: '10s',
   });
   return token;
 };
@@ -46,6 +46,8 @@ export const verifyJWT = async (token: string) => {
     ) as User;
     return decoded_token.uuid;
   } catch (err) {
-    throw new UnauthorizedError('유효하지 않은 JWT 입니다.');
+    throw new ExpireTokenError(
+      '유효하지 않은 JWT입니다. 리프레시 토큰을 보내주세요.',
+    );
   }
 };

--- a/BackEnd/src/database/controllers/question.ts
+++ b/BackEnd/src/database/controllers/question.ts
@@ -112,7 +112,9 @@ export const getQuestionById = async (
     .where('like.question_id =:questionId', { questionId })
     .getOne());
 
-  return { isLike, ...questionData };
+  const isWriter = uuid === questionData.user.uuid;
+
+  return { isLike, isWriter, ...questionData };
 };
 
 /**

--- a/BackEnd/src/routes/auth.ts
+++ b/BackEnd/src/routes/auth.ts
@@ -78,7 +78,7 @@ authRouter.delete(
 authRouter.post(
   `/check-token`,
   wrapAsync(async (req: Request, res: Response, next: NextFunction) => {
-    const refreshToken = req.body.refresh_token as string;
+    const refreshToken = req.body.refreshToken as string;
     if (refreshToken) {
       // 1. 클라이언트로부터 인계받은 리프레시 토큰이 유효한지를 조사.
       const uuid = await verifyJWT(refreshToken);
@@ -90,7 +90,7 @@ authRouter.post(
       // 2. Redis 에 저장된 토큰이 전달받은 리프레시 토큰과 동일한지 조사
       const storedRefreshToken = await getRefreshToken(uuid);
       if (storedRefreshToken != refreshToken) {
-        throw new BadRequestError(
+        throw new ForbiddenError(
           '리프레시 토큰이 유효하지 않습니다. 재로그인이 필요합니다.',
         );
       }
@@ -99,8 +99,8 @@ authRouter.post(
       const newRefreshToken = createRefreshJWT(uuid);
       await setRefreshToken(uuid, newRefreshToken);
       return res.status(200).json({
-        access_token: newAccessToken,
-        refresh_token: newRefreshToken,
+        accessToken: newAccessToken,
+        refreshToken: newRefreshToken,
       });
     }
     // 리프레시 토큰이 없을 경우, 401 에러 리턴

--- a/BackEnd/src/routes/question.ts
+++ b/BackEnd/src/routes/question.ts
@@ -15,7 +15,7 @@ import {
   postCreateQuestion,
 } from '@/database/controllers/question';
 import { BadRequestError, UnauthorizedError } from '@/errors/definedErrors';
-import { checkLoggedIn } from '@/routes/jwt';
+import { checkLoggedIn, getUserUUID } from '@/routes/jwt';
 import { wrapAsync } from '@/utils/wrapAsync';
 
 const questionRouter = express.Router();
@@ -100,6 +100,7 @@ questionRouter.delete(
 
 questionRouter.get(
   `/:qid`,
+  getUserUUID,
   wrapAsync(async (req: Request, res: Response, next: NextFunction) => {
     const questionId = Number(req.params.qid);
     const uuid = req.uuid;

--- a/FrontEnd/src/apis/auth.ts
+++ b/FrontEnd/src/apis/auth.ts
@@ -7,10 +7,6 @@ interface LoginResultType {
   token: string;
 }
 
-interface VerifyAsyncProps {
-  code: string;
-}
-
 export interface VerifyAsyncResult {
   userData: IUserData;
   accessToken: IAccessToken;
@@ -45,18 +41,30 @@ export async function logoutAsync(token: string) {
 }
 
 /**
+ * 액세스 토큰이 만료되었을 경우, 리프레시 토큰을 통해 토큰을 갱신시키는 함수
+ * @param token 사용자의 리프레시 토큰
+ * @returns 새로운 엑세스 토큰 및 리프레시 토큰, 인증 실패 시 없음.
+ */
+export async function verifyRefreshTokenAsync(token: string) {
+  const response = await postAsync<Pick<VerifyAsyncResult, "accessToken" | "refreshToken">, any>(`/auth/check-token`, {
+    refreshToken: token
+  });
+  return response;
+}
+
+/**
  * 소셜 플랫폼으로부터 인계 받은 code를 넘겨 토큰을 받는 함수
  * @param social 인증을 진행한 소셜 플랫폼 타입
  * @param code 플랫폼으로부터 넘겨 받은 인증 코드
  * @returns 서버로부터 발급한 유저의 JWT
  */
 export const verifyLoginAsync = async (social: SocialPlatform, code: string): Promise<VerifyAsyncResult | null> => {
-  const resData = await postAsync<VerifyAsyncResult, VerifyAsyncProps>(`/auth/verify/${social}`, {
+  const response = await postAsync<VerifyAsyncResult, any>(`/auth/verify/${social}`, {
     code
   });
 
-  if (resData.isSuccess) {
-    const { accessToken, refreshToken, userData } = resData.result;
+  if (response.isSuccess) {
+    const { accessToken, refreshToken, userData } = response.result;
     return { accessToken, refreshToken, userData };
   }
   return null;

--- a/FrontEnd/src/apis/question.ts
+++ b/FrontEnd/src/apis/question.ts
@@ -20,6 +20,7 @@ export interface InfQueryType<T> {
 
 export interface QuestionDetailType extends QuestionPostType {
   isLike: boolean;
+  isWriter: boolean;
   user: UserDataType;
   content: string;
   comments: CommentDataType[];
@@ -138,8 +139,10 @@ export const getQuestionsAsync = async (
  * @param questionId 정보를 가져올 질문글의 ID
  * @returns 질문글 내에 담긴 정보
  */
-export const getQuestionAsync = async (questionId: number) => {
-  const response = await getAsync<QuestionDetailType, any>(`/question/${questionId}`);
+export const getQuestionAsync = async (questionId: number, token: string) => {
+  const response = await getAsync<QuestionDetailType, any>(`/question/${questionId}`, {
+    headers: { authorization: token }
+  });
   return response;
 };
 

--- a/FrontEnd/src/components/main/Question/QuestionDetail/QuestionDetail.style.tsx
+++ b/FrontEnd/src/components/main/Question/QuestionDetail/QuestionDetail.style.tsx
@@ -15,7 +15,9 @@ export const Wrapper = styled.div`
 `;
 
 export const KeywordBox = styled.div`
+  width: 90%;
   margin: 0px 0px 32px 0px;
+
   display: flex;
   flex-wrap: wrap;
   align-items: flex-start;
@@ -34,6 +36,33 @@ export const Keyword = styled.span<StyledQuestionStateProps>`
       color: ${state == "completed" ? colors.main.pressed : colors.mono.gray6};
       font-size: ${fonts.size.lg};
       font-weight: ${fonts.weight.normal};
+    `;
+  }}
+`;
+
+export const ModifyBox = styled.div`
+  width: 10%;
+  margin: 0px 0px 32px 0px;
+
+  display: flex;
+  justify-content: space-between;
+`;
+
+export const ModifyText = styled.span`
+  ${({ theme }) => {
+    const { colors, fonts } = theme;
+    return css`
+      padding: 4px 8px;
+      margin: 0px;
+
+      color: ${colors.mono.gray5};
+      font-size: ${fonts.size.lg};
+      font-weight: ${fonts.weight.normal};
+
+      &:hover {
+        color: ${colors.mono.gray7};
+        cursor: pointer;
+      }
     `;
   }}
 `;

--- a/FrontEnd/src/components/main/Question/QuestionDetail/QuestionDetail.tsx
+++ b/FrontEnd/src/components/main/Question/QuestionDetail/QuestionDetail.tsx
@@ -4,10 +4,11 @@ import type { KeywordDataType } from "@/apis/question";
 interface QuestionDetailProps {
   content: string;
   keywords: KeywordDataType[];
+  isWriter: boolean;
   state: "progressed" | "completed";
 }
 
-const QuestionDetail = ({ content, keywords, state }: QuestionDetailProps) => {
+const QuestionDetail = ({ content, keywords, isWriter, state }: QuestionDetailProps) => {
   return (
     <style.Wrapper>
       <style.KeywordBox>
@@ -17,6 +18,12 @@ const QuestionDetail = ({ content, keywords, state }: QuestionDetailProps) => {
             <style.Keyword state={state} key={keyword.id}>{`#${keyword.content}`}</style.Keyword>
           ))}
       </style.KeywordBox>
+      {isWriter && (
+        <style.ModifyBox>
+          <style.ModifyText>{`수정`}</style.ModifyText>
+          <style.ModifyText>{`삭제`}</style.ModifyText>
+        </style.ModifyBox>
+      )}
       <style.Content>{content}</style.Content>
     </style.Wrapper>
   );

--- a/FrontEnd/src/components/template/QuestionDetailTemplate/QuestionsDetailTemplate.tsx
+++ b/FrontEnd/src/components/template/QuestionDetailTemplate/QuestionsDetailTemplate.tsx
@@ -30,7 +30,12 @@ const QuestionDetailTemplate = ({
         likesData={likesData}
         toggleLikeState={toggleLikeState}
       />
-      <QuestionDetail content={detailContent.content} keywords={detailContent.keywords} state={detailContent.state} />
+      <QuestionDetail
+        isWriter={isWriter}
+        content={detailContent.content}
+        keywords={detailContent.keywords}
+        state={detailContent.state}
+      />
       <CommentList isWriter={isWriter} state={detailContent.state} changeQuestionState={changeQuestionState} />
       <Footer />
     </>

--- a/FrontEnd/src/components/template/QuestionDetailTemplate/QuestionsDetailTemplate.tsx
+++ b/FrontEnd/src/components/template/QuestionDetailTemplate/QuestionsDetailTemplate.tsx
@@ -31,9 +31,9 @@ const QuestionDetailTemplate = ({
         toggleLikeState={toggleLikeState}
       />
       <QuestionDetail
-        isWriter={isWriter}
         content={detailContent.content}
         keywords={detailContent.keywords}
+        isWriter={isWriter}
         state={detailContent.state}
       />
       <CommentList isWriter={isWriter} state={detailContent.state} changeQuestionState={changeQuestionState} />

--- a/FrontEnd/src/pages/question/[qid].tsx
+++ b/FrontEnd/src/pages/question/[qid].tsx
@@ -6,13 +6,12 @@ import { useEffect, useState } from "react";
 import type { QuestionDetailType, LikeDataType } from "@/apis/question";
 import { getQuestionAsync, addLikesAsync, deleteLikesAsync } from "@/apis/question";
 import QuestionsDetailTemplate from "@/components/template/QuestionDetailTemplate";
-import { setUserDataAtom, accessTokenAtom } from "@/stores/actions";
+import { accessTokenAtom } from "@/stores/actions";
 
 const QuestionDetail = () => {
   const router = useRouter();
   const questionId = Number(router.query.qid);
 
-  const [userData] = useAtom(setUserDataAtom);
   const [accessToken] = useAtom(accessTokenAtom);
   const [isAnswered, setIsAnswered] = useState<boolean>(false);
   const [detailContent, setDetailContent] = useState<QuestionDetailType | undefined>(undefined);
@@ -28,11 +27,11 @@ const QuestionDetail = () => {
 
     const initializeData = async () => {
       // 질문글 컨텐츠 업데이트
-      const initDataResult = await getQuestionAsync(questionId);
+      const initDataResult = await getQuestionAsync(questionId, accessToken || "");
 
       // 질문글 관련 정보 로드 실패 시, 이전으로 되돌아감.
       if (!initDataResult.isSuccess) {
-        router.back();
+        router.replace("/questions");
       }
       setDetailContent(prev => (initDataResult.isSuccess ? initDataResult.result : prev));
 
@@ -48,10 +47,7 @@ const QuestionDetail = () => {
     };
 
     initializeData();
-  }, [router.isReady, questionId, userData, isAnswered]);
-
-  const isWriter = userData.uuid === detailContent?.user.uuid;
-  console.log(userData.uuid, detailContent?.user.uuid);
+  }, [router.isReady, questionId, isAnswered]);
 
   const changeQuestionState = () => {
     setIsAnswered(true);
@@ -80,6 +76,8 @@ const QuestionDetail = () => {
   if (detailContent == undefined) {
     return <span>Loading...</span>;
   }
+
+  const isWriter = detailContent.isWriter;
 
   return (
     <>


### PR DESCRIPTION
## Topic
로그인 시에만 접속 가능한 라우터 설계 (#16)
JWT 토큰 발급, Social 로그인 구현 (#2)

## Desc

Axios intercepter를 활용하여 리프레시 토큰을 검증한 후, 새로운 토큰을 발급받도록 하였습니다.
만약 리프레시 토큰도 유효하지 않을 경우, 자동으로 로그아웃을 진행하도록 하였습니다.
질문글 상세 페이지 열람 시, 자신이 작성자인지를 검증하는 로직을 추가하였습니다.